### PR TITLE
HTML formatting

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -1,0 +1,19 @@
+document.addEventListener("DOMContentLoaded", function () {
+    // Select all select elements within .input-group
+    var selects = document.querySelectorAll('.input-group select');
+
+    // Loop over each select element
+    selects.forEach(function (select) {
+        // Create a non-breaking space and add it before the select element
+        var nbsp = document.createTextNode('\u00A0');
+        select.parentNode.insertBefore(nbsp, select);
+
+        // Create and append two line break elements after the select element
+        var br1 = document.createElement('br');
+        var br2 = document.createElement('br');
+
+        // Append line breaks after the select element
+        select.parentNode.insertBefore(br1, select.nextSibling);
+        select.parentNode.insertBefore(br2, br1.nextSibling);
+    });
+});

--- a/templates/base.html
+++ b/templates/base.html
@@ -56,5 +56,6 @@
 <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js"
         integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM"
         crossorigin="anonymous"></script>
+<script src="/static/script.js"></script>
 </body>
 </html>

--- a/templates/fyfpage.html
+++ b/templates/fyfpage.html
@@ -11,15 +11,15 @@
             <label for="text" style="display: block">Text*
                 <textarea name="text" placeholder="Gib einen Text mit einer rhetorischen Figur ein!"
                           class="form-control" {% if readonly %}readonly="readonly"{% endif %}>{{ text }}</textarea>
-                <button type="submit" class="btn btn-success float-right" id="get_example_button"
+            </label>
+            <button type="submit" class="btn btn-success float-right" id="get_example_button"
                         name="get_example_button">
                     Oder Beispiel aus Datenbank
-                </button>
-            </label>
+            </button>
         </div>
 
         <div class="form-group">
-            <label for="context" style="display: block">Kontext
+            <label for="context" style="display: block"><br>Kontext
                 <textarea name="context"
                           placeholder="Der Kontext, in dem der 'Text' steht, also z.B. Sätze die vor oder nach der rhetorischen Figur stehen."
                           class="form-control" {% if readonly %}readonly="readonly"{% endif %}>{{ context }}</textarea>


### PR DESCRIPTION
This PR contributes following changes:

- Put `button` outside label,
- Add a break between `button` and `Kontext` form-group,
- Add space before and between `select`